### PR TITLE
Reduce Ambiguity in MVVM (Full) CommandBinding

### DIFF
--- a/MVVM/CommandBinding.cls
+++ b/MVVM/CommandBinding.cls
@@ -147,11 +147,11 @@ Private Property Get ICommandBinding_Command() As ICommand
     Set ICommandBinding_Command = this.Command
 End Property
 
-Private Sub ICommandBinding_EvaluateCanExecute
+Private Sub ICommandBinding_EvaluateCanExecute()
     EvaluateCanExecute
 End Sub
 
-Private Sub EvaluateCanExecute
+Private Sub EvaluateCanExecute()
     If this.Target Is Nothing Then Exit Sub
     If this.Command Is Nothing Then
         this.Target.Enabled = False

--- a/MVVM/CommandBinding.cls
+++ b/MVVM/CommandBinding.cls
@@ -147,16 +147,16 @@ Private Property Get ICommandBinding_Command() As ICommand
     Set ICommandBinding_Command = this.Command
 End Property
 
-Private Sub ICommandBinding_EvaluateCanExecute(ByVal Context As Object)
-    EvaluateCanExecute Context
+Private Sub ICommandBinding_EvaluateCanExecute
+    EvaluateCanExecute
 End Sub
 
-Private Sub EvaluateCanExecute(ByVal Source As Object)
+Private Sub EvaluateCanExecute
     If this.Target Is Nothing Then Exit Sub
     If this.Command Is Nothing Then
         this.Target.Enabled = False
     Else
-        this.Target.Enabled = this.Command.CanExecute(Source)
+        this.Target.Enabled = this.Command.CanExecute(this.ViewModel)
     End If
 End Sub
 

--- a/MVVM/ICommandBinding.cls
+++ b/MVVM/ICommandBinding.cls
@@ -25,6 +25,6 @@ Attribute Command.VB_Description = "Gets the command bound to the event source."
 End Property
 
 '@Description "Evaluates whether the command can execute given the binding context."
-Public Sub EvaluateCanExecute
+Public Sub EvaluateCanExecute()
 Attribute EvaluateCanExecute.VB_Description = "Evaluates whether the command can execute given the binding context."
 End Sub

--- a/MVVM/ICommandBinding.cls
+++ b/MVVM/ICommandBinding.cls
@@ -25,6 +25,6 @@ Attribute Command.VB_Description = "Gets the command bound to the event source."
 End Property
 
 '@Description "Evaluates whether the command can execute given the binding context."
-Public Sub EvaluateCanExecute(ByVal Context As Object)
+Public Sub EvaluateCanExecute
 Attribute EvaluateCanExecute.VB_Description = "Evaluates whether the command can execute given the binding context."
 End Sub


### PR DESCRIPTION
First time using github / proposing changes so apologies if wrong process followed here.

Summary of proposed change (also hopefully documented in specific commits):
Changes should update MVVM example to update ICommandBinding and CommandBinding classes to remove the Context object  parameter input to "EvaluateCanExecute" in the ICommandBinding interface.

Couple reasons to remove the Context input to EvaluateCanExcute

1. The current interface requires a caller/user of the interface to know the Context the CommandBinding is going to 'auto-execute' the Command in (e.g. to be carrying around a copy of ViewModel since the current implementation of CommandBinding will only execute in that stored context) in order to use ICommandBinding.EvaluateCanExecute.  

2. Anything that will want to evaluate the command's canexecute in a alternate specific context can still access the command's can execute through the Command property on the ICommand interface - 

As an alternative, one could change the signature for EvaluateCanExecute to EvaluateCanExecute(Optional Context as object).  This would have advantage of not making it a breaking change... but this would still leave an ambiguity/confusion between the interface and the specific implementation provided as an example - and it seems to me as this is provided as a teaching example  / potential framework, the purpose of a CommandBinding is to encapsulate all of the dependencies on the linkage and so should be independent of evaluating the Command in arbitrary contexts.

Above offered in light of reading about MVVM-lite and hopefully is helpful